### PR TITLE
Add build instructions for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,3 +270,17 @@ Here's the tl;dr guide to building:
 
 * that's it!
     > ./HTTPReJect --help
+
+## Windows
+Perform these steps, then proceed with the tl;dr version, replacing export with the windows-equivalent of set.
+ 
+ * Download winpcap developer version
+    > https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
+ 
+ * Since winpcap dev is 32-bit only, we must set GOARCH accordingly
+    > set GOARCH=386
+    
+ * Enable CGO
+    > set CGO_ENABLED=1
+    
+ * Ready to go!


### PR DESCRIPTION
Add running instructions for Winodws (32/64 bit) - since winpcap dev is only available in 32 bit for windows, we'll be running in 32 bit mode anyway. Also, finding the download itself is not an easy task so I've added a link to it.