### PR TITLE
Fix 8-byte alignment issue in readerAndTime

### DIFF
--- a/alignment_test.go
+++ b/alignment_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+	"sync/atomic"
+)
+
+// Make sure the int64 fields of ReaderAndTime struct are 8-byte aligned.
+// If they are not, this test will fail on win32, ARM (or win64/linux running with GOARCH=386),
+// Perform atomic read&write of both fields to ensure both are placed correctly.
+// Run this test with GOARCH=386
+func TestReaderAndTimeAlignment(*testing.T) {
+	rat := new(readerAndTime)
+	atomic.AddInt64(&rat.unixNano, 10)
+	atomic.AddInt64(&rat.lastUnixNano, 10)
+}

--- a/httpreject.go
+++ b/httpreject.go
@@ -239,10 +239,13 @@ const (
 	Error    RunnerType = iota
 )
 
+//unixNano and lastUnixNano fields must be placed on top of the struct,
+//since their addresses must be 8-byte aligned.
+//see https://github.com/golang/go/issues/5278 for further information.
 type readerAndTime struct {
-	tcpreader.ReaderStream
 	unixNano       int64
 	lastUnixNano   int64
+	tcpreader.ReaderStream
 	pcapStreamSide chan RunnerType
 	started        bool
 	key            *netKey


### PR DESCRIPTION
When running on windows, we must use winpcap dev version which is only available in 32 bit build. This means we must set GOARCH=386 to run it.
There seems to be a known bug in golang (namely: https://github.com/golang/go/issues/5278 - seems to have already turned into a "feature") where the atomic.Load/Store instructions and their derivatives require their arguments to be on 8-byte aligned addresses (apparently due to lack of support for HW instructions). This was not the case for the readerAndTime struct: its first field was tcp.readerStream whose size is apparently not a multiplicand of 8 bytes. It is followed by the int64 fields unixNano and lastUnixNano which were the arguments for atomic.* ops, causing those ops to fail.

Since structs are guaranteed to be 8 byte aligned, the solution is simply to move the int64 fields to the top of the struct (since, well, int64 is also 8 bytes).

A corresponding test has been added and should also be tested on Linux systems with GOARCH=386